### PR TITLE
Add Dungeon Master page

### DIFF
--- a/character_sheet.html
+++ b/character_sheet.html
@@ -78,6 +78,7 @@ footer{text-align:center;margin-top:2rem;color:#777;font-size:.8rem}
   <a href="general_rules.html">Rules</a>
   <a href="lists.html">Lists</a>
   <a href="character_sheet.html">Sheet</a>
+  <a href="dungeon_master.html">Dungeon Master</a>
 </nav>
 
 <h1>FEIM Character Sheet</h1>

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,54 @@
+:root{
+  --amber:#ffb84d;
+  --bg:#1a1a1a;
+  --fg:#f5f3ef;
+  --panel:#2a2a2a;
+  --border:#444;
+}
+body{font-family:sans-serif;background:var(--bg);color:var(--fg);max-width:680px;margin:auto;padding:1rem}
+h1,h2{color:var(--amber);border-bottom:1px solid #555;padding-bottom:.2rem;margin-top:1.5rem}
+label{font-weight:bold;margin-top:1rem;display:block}
+input,textarea,select{background:var(--panel);color:var(--fg);border:1px solid var(--border);padding:.6rem}
+input[type=text],input[type=number],textarea{width:100%;box-sizing:border-box;margin-top:.3rem}
+input[type=number]{max-width:90px}
+.stats{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+.mod{font-size:.85rem;margin-left:4px;color:#aaa;font-weight:normal}
+table{width:100%;border-collapse:collapse;margin-top:.5rem;font-size:.9rem}
+th,td{border:1px solid var(--border);padding:.4rem}
+th{background:#333}
+.row1{font-weight:600}
+.cost{text-align:right;width:34%}
+.descr{font-size:.85rem;color:#ccc}
+.slider-wrap{display:flex;align-items:center;gap:.5rem;margin-top:1rem}
+button,.slot-btn{background:#333;border:1px solid var(--border);color:var(--amber);touch-action:none}
+.slider-wrap button{width:38px;height:38px;font-size:1.2rem}
+.slot-btn{width:32px;height:32px;margin-right:.4rem;font-size:1rem;padding:0}
+.slider-wrap span{min-width:48px;text-align:right}
+input[type=range]{flex:1;height:34px;appearance:none;background:transparent}
+input[type=range]::-webkit-slider-thumb{appearance:none;width:30px;height:30px;background:var(--amber);border-radius:50%;border:none}
+input[type=range]::-webkit-slider-runnable-track{height:8px;background:#555;border-radius:4px}
+input[type=range]::-moz-range-thumb{width:30px;height:30px;background:var(--amber);border:none;border-radius:50%}
+input[type=range]::-moz-range-track{height:8px;background:#555;border-radius:4px}
+a{color:var(--amber);text-decoration:none;font-weight:600}
+a:hover{text-decoration:underline}
+nav{display:flex;flex-wrap:wrap;gap:.8rem;margin-bottom:1rem}
+nav a{background:#333;padding:.4rem .7rem;border-radius:4px}
+@media (max-width:480px){
+  body{padding:.6rem}
+  nav a{font-size:.9rem}
+  table{font-size:.8rem}
+}
+.btn{padding:.45rem .7rem;border-radius:4px;margin-top:.4rem;font-size:.9rem}
+footer{text-align:center;margin-top:2rem;color:#777;font-size:.8rem}
+#picker{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;flex-direction:column;align-items:center;padding:1rem;z-index:1000}
+#picker input{width:100%;max-width:360px;margin-bottom:.6rem}
+#picker ul{max-height:60vh;overflow:auto;width:100%;max-width:360px;padding:0;margin:0;list-style:none}
+#picker li{padding:.4rem .6rem;border:1px solid var(--border);margin-bottom:.4rem;cursor:pointer}
+@media(max-width:480px){body{padding:.6rem}table{font-size:.8rem}}
+.lvl-row label{flex:1 1 32%;min-width:90px}
+@media(max-width:480px){
+  .lvl-row{flex-wrap:wrap}
+  .lvl-row label{flex:1 1 100%}
+}
+.monster-card{background:var(--panel);padding:.5rem;margin:.5rem 0;border:1px solid var(--border)}
+.monster-card strong{display:block;margin-bottom:.3rem}

--- a/dungeon_master.html
+++ b/dungeon_master.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Dungeon Master – FEIM</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="progression.html">Progression</a>
+    <a href="combat_rules.html">Combat</a>
+    <a href="general_rules.html">Rules</a>
+    <a href="lists.html">Lists</a>
+    <a href="character_sheet.html">Sheet</a>
+    <a href="dungeon_master.html">Dungeon Master</a>
+  </nav>
+
+  <h1>Dungeon Master</h1>
+
+  <details id="gamedata-editor">
+    <summary>Game Data Editor</summary>
+    <label for="typeSel">Type</label>
+    <select id="typeSel">
+      <option value="skill">skill</option>
+      <option value="item">item</option>
+      <option value="monster">monster</option>
+    </select>
+    <label for="name">Name</label>
+    <input id="name" type="text">
+    <label for="desc">Description</label>
+    <textarea id="desc" rows="2"></textarea>
+
+    <div id="skillFields" class="type-fields">
+      <label for="gd_damage">Damage</label>
+      <input id="gd_damage" type="text">
+      <label for="gd_cooldown">Cooldown</label>
+      <input id="gd_cooldown" type="text">
+      <label for="gd_element">Element</label>
+      <input id="gd_element" type="text">
+    </div>
+
+    <div id="itemFields" class="type-fields" style="display:none">
+      <label for="gd_rarity">Rarity</label>
+      <input id="gd_rarity" type="text">
+      <label for="gd_effect">Effect</label>
+      <input id="gd_effect" type="text">
+      <label for="gd_stack">Stack</label>
+      <input id="gd_stack" type="number" min="1" value="1">
+    </div>
+
+    <div id="monsterFields" class="type-fields" style="display:none">
+      <label for="gd_hp">HP</label>
+      <input id="gd_hp" type="number" min="1" value="1">
+      <label for="gd_stamina">Stamina</label>
+      <input id="gd_stamina" type="number" min="0" value="0">
+      <label for="gd_mana">Mana</label>
+      <input id="gd_mana" type="number" min="0" value="0">
+      <label for="gd_baseAtk">Base Atk</label>
+      <input id="gd_baseAtk" type="text">
+      <label for="gd_loot">Loot</label>
+      <input id="gd_loot" type="text">
+    </div>
+
+    <button id="saveBtn" class="btn">💾 Salva</button>
+    <input id="filterInput" placeholder="Filter list" type="text" style="margin-top:1rem">
+    <ul id="gamedataList"></ul>
+  </details>
+
+  <details id="encounter-manager">
+    <summary>Encounter Manager</summary>
+    <select id="monsterSelect"></select>
+    <button id="addMonster" class="btn">Add monster</button>
+    <div id="encounterArea"></div>
+  </details>
+
+  <details id="turn-tracker">
+    <summary>Turn Tracker</summary>
+    <button id="nextTurn" class="btn">➡️ Prossimo Turno</button>
+    <ul id="log" aria-live="polite"></ul>
+  </details>
+
+  <script type="module" src="js/dungeon_master.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@ th{background:#333}
   <a href="general_rules.html">Rules</a>
   <a href="lists.html">Lists</a>
   <a href="character_sheet.html">Sheet</a>
+  <a href="dungeon_master.html">Dungeon Master</a>
 </nav>
 
 <h1>FEIM: On the Table</h1>

--- a/js/dungeon_master.js
+++ b/js/dungeon_master.js
@@ -1,0 +1,136 @@
+import { q, qq, setVal } from './feim_utils.js';
+
+let gameData = {};
+let encounter = { turn: 1, monsters: [], log: [] };
+
+export async function loadGameData(){
+  const ls = localStorage.getItem('gamedata');
+  if(ls){
+    gameData = JSON.parse(ls);
+    renderGameDataList();
+    fillMonsterSelect();
+  }else{
+    const d = await fetch('gamedata.json').then(r=>r.json());
+    gameData = d;
+    localStorage.setItem('gamedata', JSON.stringify(d));
+    renderGameDataList();
+    fillMonsterSelect();
+  }
+}
+
+export function saveGameData(obj){
+  const key = obj.category + 's';
+  gameData[key] = gameData[key] || [];
+  const idx = gameData[key].findIndex(o=>o.id===obj.id);
+  if(idx>-1) gameData[key][idx] = obj; else gameData[key].push(obj);
+  localStorage.setItem('gamedata', JSON.stringify(gameData));
+  renderGameDataList();
+  fillMonsterSelect();
+}
+
+export function spawnMonster(id){
+  const src = (gameData.monsters||[]).find(m=>m.id===id);
+  if(!src) return;
+  const m = JSON.parse(JSON.stringify(src));
+  encounter.monsters.push(m);
+  renderEncounter();
+  persistEncounter();
+}
+
+export function updateBar(node,val){
+  setVal(node,val);
+  node.nextElementSibling.textContent = val;
+}
+
+export function log(msg){
+  encounter.log.push(msg);
+  const li = document.createElement('li');
+  li.textContent = msg;
+  q('#log').appendChild(li);
+  persistEncounter();
+}
+
+export function nextTurn(){
+  encounter.turn++;
+  log('Turno '+encounter.turn);
+}
+
+function persistEncounter(){
+  sessionStorage.setItem('encounter', JSON.stringify(encounter));
+}
+
+function loadEncounter(){
+  const ls = sessionStorage.getItem('encounter');
+  if(ls) encounter = JSON.parse(ls);
+  renderEncounter();
+  q('#log').innerHTML = encounter.log.map(l=>`<li>${l}</li>`).join('');
+}
+
+function fillMonsterSelect(){
+  const sel = q('#monsterSelect');
+  sel.innerHTML = (gameData.monsters||[]).map(m=>`<option value="${m.id}">${m.name}</option>`).join('');
+}
+
+function renderGameDataList(){
+  const f = q('#filterInput').value.toLowerCase();
+  const lists = [...(gameData.skills||[]),(gameData.items||[]),...(gameData.monsters||[])].flat();
+  q('#gamedataList').innerHTML = lists.filter(o=>o.name.toLowerCase().includes(f)).map(o=>`<li>${o.name}</li>`).join('');
+}
+
+function renderEncounter(){
+  const area = q('#encounterArea');
+  area.innerHTML = encounter.monsters.map((m,i)=>{
+    return `<div class="monster-card"><strong>${m.name}</strong> <button class="del" data-i="${i}">×</button>
+      <div class="slider-wrap">HP <input type="range" class="bar" data-i="${i}" data-k="hp" min="0" max="${m.hp}" value="${m.hp}"><span>${m.hp}</span></div>
+      <div class="slider-wrap">ST <input type="range" class="bar" data-i="${i}" data-k="stamina" min="0" max="${m.stamina||0}" value="${m.stamina||0}"><span>${m.stamina||0}</span></div>
+      <div class="slider-wrap">MP <input type="range" class="bar" data-i="${i}" data-k="mana" min="0" max="${m.mana||0}" value="${m.mana||0}"><span>${m.mana||0}</span></div>
+      ${(m.skills||[]).map(s=>`<button class="act" data-s="${s}" data-i="${i}">${s}</button>`).join('')}
+    </div>`;
+  }).join('');
+  qq('.del').forEach(b=>b.onclick=e=>{encounter.monsters.splice(b.dataset.i,1);renderEncounter();persistEncounter();});
+  qq('.bar').forEach(sl=>sl.oninput=e=>{
+    const i = +sl.dataset.i;
+    const key = sl.dataset.k;
+    encounter.monsters[i][key] = +sl.value;
+    sl.nextElementSibling.textContent = sl.value;
+    persistEncounter();
+  });
+}
+
+q('#saveBtn').onclick = () => {
+  const type = q('#typeSel').value;
+  const obj = {
+    id: q('#name').value.trim().toLowerCase().replace(/\s+/g,'-'),
+    name: q('#name').value.trim(),
+    description: q('#desc').value.trim(),
+    category: type
+  };
+  if(type==='skill'){
+    obj.damage = q('#gd_damage').value;
+    obj.cooldown = q('#gd_cooldown').value;
+    obj.element = q('#gd_element').value;
+  }else if(type==='item'){
+    obj.rarity = q('#gd_rarity').value;
+    obj.effect = q('#gd_effect').value;
+    obj.stack = +q('#gd_stack').value||1;
+  }else{
+    obj.hp = +q('#gd_hp').value||0;
+    obj.stamina = +q('#gd_stamina').value||0;
+    obj.mana = +q('#gd_mana').value||0;
+    obj.baseAtk = q('#gd_baseAtk').value;
+    obj.loot = q('#gd_loot').value;
+  }
+  saveGameData(obj);
+};
+
+q('#typeSel').onchange = () => {
+  qq('.type-fields').forEach(div=>div.style.display='none');
+  q('#'+q('#typeSel').value+'Fields').style.display='block';
+};
+
+q('#addMonster').onclick = () => spawnMonster(q('#monsterSelect').value);
+q('#filterInput').oninput = renderGameDataList;
+q('#nextTurn').onclick = nextTurn;
+
+loadGameData();
+loadEncounter();

--- a/js/feim_utils.js
+++ b/js/feim_utils.js
@@ -1,0 +1,6 @@
+export const q = s => document.querySelector(s);
+export const qq = s => document.querySelectorAll(s);
+export function setVal(el, val){
+  el.value = val;
+  el.dispatchEvent(new Event('input'));
+}


### PR DESCRIPTION
## Summary
- add a new Dungeon Master page with editor, encounter manager and turn tracker
- create shared CSS and utility functions
- link the new page from index and character sheet

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6877bc5e42048323901a7ea20c6c26a2