### PR TITLE
Update DM page with action list support

### DIFF
--- a/dungeon_master.html
+++ b/dungeon_master.html
@@ -5,31 +5,68 @@
 <title>Dungeon Master – FEIM</title>
 <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no">
 <style>
-:root{--amber:#ffb84d;--bg:#1a1a1a;--fg:#f5f3ef;--panel:#2a2a2a;--border:#444}
-body{font-family:sans-serif;background:var(--bg);color:var(--fg);max-width:680px;margin:auto;padding:1rem}
-h1,h2{color:var(--amber);border-bottom:1px solid #555;padding-bottom:.2rem;margin-top:1.5rem}
+:root{
+  --amber:#ffb84d;
+  --bg:#1a1a1a;
+  --fg:#f5f3ef;
+  --panel:#2a2a2a;
+  --border:#444;
+}
+body{
+  font-family:sans-serif;
+  background:var(--bg);
+  color:var(--fg);
+  max-width:680px;
+  margin:auto;
+  padding:1rem;
+}
+h1,h2{
+  color:var(--amber);
+  border-bottom:1px solid #555;
+  padding-bottom:.2rem;
+  margin-top:1.5rem;
+}
 label{font-weight:bold;margin-top:1rem;display:block}
-input,textarea,select,button{background:var(--panel);color:var(--fg);border:1px solid var(--border);padding:.6rem}
-input[type=text],input[type=number],textarea,select{width:100%;box-sizing:border-box;margin-top:.3rem}
+input,textarea,select,button{
+  background:var(--panel);
+  color:var(--fg);
+  border:1px solid var(--border);
+  padding:.6rem;
+}
+input[type=text],input[type=number],textarea,select{
+  width:100%;
+  box-sizing:border-box;
+  margin-top:.3rem;
+}
 input[type=number]{max-width:90px}
+nav{display:flex;flex-wrap:wrap;gap:.8rem;margin-bottom:1rem}
+nav a{
+  background:#333;
+  padding:.4rem .7rem;
+  border-radius:4px;
+  color:var(--amber);
+  text-decoration:none;
+  font-weight:600;
+}
+nav a:hover{text-decoration:underline}
 .slider-wrap{display:flex;align-items:center;gap:.5rem;margin-top:1rem}
-.slider-wrap button{width:38px;height:38px;font-size:1.2rem}
 .slider-wrap span{min-width:48px;text-align:right}
 button.btn{padding:.45rem .7rem;border-radius:4px;margin-top:.4rem;font-size:.9rem}
-nav{display:flex;flex-wrap:wrap;gap:.8rem;margin-bottom:1rem}
-nav a{background:#333;padding:.4rem .7rem;border-radius:4px;color:var(--amber);text-decoration:none;font-weight:600}
-nav a:hover{text-decoration:underline}
-ul{padding:0;list-style:none}
-li{margin:.3rem 0}
-.del-entry{margin-left:.4rem;color:red}
-.monster-card{background:var(--panel);padding:.5rem;margin:.5rem 0;border:1px solid var(--border)}
+.monster-card{background:var(--panel);padding:.5rem;margin:.5rem 0;border:1px solid var(--border)}
 .monster-card strong{display:block;margin-bottom:.3rem}
 .type-fields{margin-top:.6rem;display:none}
+footer{text-align:center;margin-top:2rem;color:#777;font-size:.8rem}
 #picker{position:fixed;inset:0;background:rgba(0,0,0,.8);display:none;flex-direction:column;align-items:center;padding:1rem;z-index:1000}
 #picker input,#picker ul{width:100%;max-width:360px;margin-bottom:.6rem}
 #picker ul{max-height:60vh;overflow:auto;padding:0;list-style:none}
 #picker li{padding:.4rem .6rem;border:1px solid var(--border);margin-bottom:.4rem;cursor:pointer}
-footer{text-align:center;margin-top:2rem;color:#777;font-size:.8rem}
+.action-list{padding:.6rem;display:flex;flex-direction:column;gap:.5rem}
+.action-item{padding:.5rem;border:1px solid var(--border);border-radius:4px}
+.action-item>.title{display:flex;justify-content:space-between;align-items:center;cursor:pointer}
+.action-item>.details{display:none;padding-top:.4rem;font-size:.85rem;color:#ccc}
+.editor-list{margin-top:.6rem}
+.editor-item{padding:.4rem;border:1px solid var(--border);margin-bottom:.4rem;cursor:pointer}
+.editor-item .title{font-weight:600}
 </style>
 </head>
 <body>
@@ -43,139 +80,185 @@ footer{text-align:center;margin-top:2rem;color:#777;font-size:.8rem}
   <a href="dungeon_master.html">Dungeon Master</a>
   <a href="settings.html">Settings</a>
 </nav>
-
 <h1>Dungeon Master</h1>
+<label>Filtro globale:</label>
+<input id="globalFilter" placeholder="Filtra…">
+<div class="container">
+  <section id="encounter-manager">
+    <h2>Encounter Manager</h2>
+    <select id="monsterSelect"></select>
+    <button id="addMonster" class="btn">+ Mostro</button>
+    <div id="encounterArea"></div>
+  </section>
+  <section id="gamedata-editor">
+    <h2>Game Data Editor</h2>
+    <p style="text-align:right">
+      <button id="exportGameDataBtn" class="btn">Export JSON</button>
+      <input id="importGameDataFile" type="file" accept=".json" style="display:none">
+      <button id="importGameDataBtn" class="btn">Import JSON</button>
+    </p>
+    <label>Type
+      <select id="typeSel">
+        <option value="skill">skill</option>
+        <option value="spell">spell</option>
+        <option value="weapon">weapon</option>
+        <option value="armor">armor</option>
+        <option value="item">item</option>
+        <option value="monster">monster</option>
+      </select>
+    </label>
+    <label>ID <input id="gd_id" type="text"></label>
+    <label>Name <input id="gd_name" type="text"></label>
+    <label>Description <textarea id="gd_description" rows="2"></textarea></label>
 
-<details id="gamedata-editor" open>
-  <summary>Game Data Editor</summary>
-  <p style="text-align:right">
-    <button id="exportGameDataBtn" class="btn">Export JSON</button>
-    <input id="importGameDataFile" type="file" accept=".json" style="display:none">
-    <button id="importGameDataBtn" class="btn">Import JSON</button>
-  </p>
+    <div id="skillFields" class="type-fields">
+      <label>Type<select id="gd_type">
+        <option>melee</option><option>ranged</option><option>movement</option>
+        <option>defense</option><option>stealth</option>
+      </select></label>
+      <label>Time<input id="gd_time" type="number" min="0" step="0.1" value="1"></label>
+      <label>Cost Resource<select id="gd_cost_resource">
+        <option value="stamina">stamina</option><option value="mana">mana</option>
+      </select></label>
+      <label>Cost Amount<input id="gd_cost_amount" type="number" min="0" value="1"></label>
+      <label>Effect JSON<textarea id="gd_effect_json" rows="3" placeholder='{"kind":"weapon-damage","multiplier":1.5}'></textarea></label>
+    </div>
 
-  <label>Type
-    <select id="typeSel">
-      <option value="skill">skill</option>
-      <option value="spell">spell</option>
-      <option value="weapon">weapon</option>
-      <option value="armor">armor</option>
-      <option value="item">item</option>
-      <option value="monster">monster</option>
-    </select>
-  </label>
-  <label>ID <input id="gd_id" type="text"></label>
-  <label>Name <input id="gd_name" type="text"></label>
-  <label>Description <textarea id="gd_description" rows="2"></textarea></label>
+    <div id="spellFields" class="type-fields">
+      <label>Time<input id="gd_time" type="number" min="0" step="0.1" value="2"></label>
+      <label>Cost JSON<textarea id="gd_spell_cost_json" rows="2" placeholder='{"resource":"mana","amount":2}'></textarea></label>
+      <label>Effect JSON<textarea id="gd_spell_effect_json" rows="3" placeholder='{"kind":"damage","dice":"1d6","scales_with":"MAG"}'></textarea></label>
+    </div>
 
-  <div id="skillFields" class="type-fields">
-    <label>Type<select id="gd_type">
-      <option>melee</option><option>ranged</option><option>movement</option>
-      <option>defense</option><option>stealth</option>
-    </select></label>
-    <label>Time<input id="gd_time" type="number" min="0" step="0.1" value="1"></label>
-    <label>Cost Resource<select id="gd_cost_resource">
-      <option value="stamina">stamina</option><option value="mana">mana</option>
-    </select></label>
-    <label>Cost Amount<input id="gd_cost_amount" type="number" min="0" value="1"></label>
-    <label>Effect JSON<textarea id="gd_effect_json" rows="3"
-      placeholder='{"kind":"weapon-damage","multiplier":1.5}'></textarea></label>
-  </div>
+    <div id="weaponFields" class="type-fields">
+      <label>Type<select id="gd_weapon_type">
+        <option>melee</option><option>ranged</option><option>magic</option>
+      </select></label>
+      <label>Damage JSON<textarea id="gd_weapon_damage_json" rows="2" placeholder='{"dice":"1d6","stat":"STR"}'></textarea></label>
+      <label>Notes<input id="gd_weapon_notes" type="text"></label>
+    </div>
 
-  <div id="spellFields" class="type-fields">
-    <label>Time<input id="gd_time" type="number" min="0" step="0.1" value="2"></label>
-    <label>Cost JSON<textarea id="gd_spell_cost_json" rows="2"
-      placeholder='{"resource":"mana","amount":2}'></textarea></label>
-    <label>Effect JSON<textarea id="gd_spell_effect_json" rows="3"
-      placeholder='{"kind":"damage","dice":"1d6","scales_with":"MAG"}'></textarea></label>
-  </div>
+    <div id="armorFields" class="type-fields">
+      <label>Slot<select id="gd_armor_slot">
+        <option value="head">head</option><option value="chest">chest</option><option value="legs">legs</option>
+      </select></label>
+      <label>DEF<input id="gd_armor_def" type="number" min="0" value="1"></label>
+      <label>Penalty<input id="gd_armor_penalty" type="text"></label>
+    </div>
 
-  <div id="weaponFields" class="type-fields">
-    <label>Type<select id="gd_weapon_type">
-      <option>melee</option><option>ranged</option><option>magic</option>
-    </select></label>
-    <label>Damage JSON<textarea id="gd_weapon_damage_json" rows="2"
-      placeholder='{"dice":"1d6","stat":"STR"}'></textarea></label>
-    <label>Notes<input id="gd_weapon_notes" type="text"></label>
-  </div>
+    <div id="itemFields" class="type-fields">
+      <label>Type<input id="gd_item_type" type="text"></label>
+      <label>Effect JSON<textarea id="gd_item_effect_json" rows="2" placeholder='{"kind":"heal","dice":"1d8"}'></textarea></label>
+    </div>
 
-  <div id="armorFields" class="type-fields">
-    <label>Slot<select id="gd_armor_slot">
-      <option value="head">head</option><option value="chest">chest</option><option value="legs">legs</option>
-    </select></label>
-    <label>DEF<input id="gd_armor_def" type="number" min="0" value="1"></label>
-    <label>Penalty<input id="gd_armor_penalty" type="text"></label>
-  </div>
+    <div id="monsterFields" class="type-fields">
+      <label>HP<input id="gd_hp" type="number" min="1" value="1"></label>
+      <label>Stamina<input id="gd_stamina" type="number" min="0" value="0"></label>
+      <label>Mana<input id="gd_mana" type="number" min="0" value="0"></label>
+      <label>STR<input id="gd_str" type="number" min="0" value="1"></label>
+      <label>DEX<input id="gd_dex" type="number" min="0" value="1"></label>
+      <label>CON<input id="gd_con" type="number" min="0" value="1"></label>
+      <label>END<input id="gd_end" type="number" min="0" value="1"></label>
+      <label>MAG<input id="gd_mag" type="number" min="0" value="0"></label>
+      <label>WIS<input id="gd_wis" type="number" min="0" value="0"></label>
+      <label>Base Atk<input id="gd_baseAtk" type="text"></label>
+      <label>Loot<input id="gd_loot" type="text"></label>
+      <h3>Skills</h3>
+      <table id="gd_skills_table"><tbody></tbody></table>
+      <button id="addGDMonsterSkill" class="btn">+ Skill</button>
+    </div>
 
-  <div id="itemFields" class="type-fields">
-    <label>Type<input id="gd_item_type" type="text"></label>
-    <label>Effect JSON<textarea id="gd_item_effect_json" rows="2"
-      placeholder='{"kind":"heal","dice":"1d8"}'></textarea></label>
-  </div>
-
-  <div id="monsterFields" class="type-fields">
-    <label>HP<input id="gd_hp" type="number" min="1" value="1"></label>
-    <label>Stamina<input id="gd_stamina" type="number" min="0" value="0"></label>
-    <label>Mana<input id="gd_mana" type="number" min="0" value="0"></label>
-    <label>STR<input id="gd_str" type="number" min="0" value="1"></label>
-    <label>DEX<input id="gd_dex" type="number" min="0" value="1"></label>
-    <label>CON<input id="gd_con" type="number" min="0" value="1"></label>
-    <label>END<input id="gd_end" type="number" min="0" value="1"></label>
-    <label>MAG<input id="gd_mag" type="number" min="0" value="0"></label>
-    <label>WIS<input id="gd_wis" type="number" min="0" value="0"></label>
-    <label>Base Atk<input id="gd_baseAtk" type="text"></label>
-    <label>Loot<input id="gd_loot" type="text"></label>
-    <h3>Skills</h3>
-    <table id="gd_skills_table"><tbody></tbody></table>
-    <button id="addGDMonsterSkill" class="btn">+ Skill</button>
-  </div>
-
-  <button id="saveBtn" class="btn">💾 Salva / Aggiorna</button>
-  <button id="delBtn" class="btn" style="display:none">🗑 Elimina</button>
-  <input id="filterInput" placeholder="filtra elenco" type="text" style="margin-top:1rem">
-  <ul id="gamedataList"></ul>
-</details>
-
-<details id="encounter-manager" open>
-  <summary>Encounter Manager</summary>
-  <select id="monsterSelect"></select>
-  <button id="addMonster" class="btn">+ Mostro</button>
-  <div id="encounterArea"></div>
-</details>
-
+    <button id="saveBtn" class="btn">💾 Salva / Aggiorna</button>
+    <button id="delBtn" class="btn" style="display:none">🗑 Elimina</button>
+    <input id="gdFilter" placeholder="Filtra…">
+    <div id="gdataList" class="editor-list"></div>
+  </section>
+</div>
 <div id="picker">
   <input id="pickerSearch" placeholder="Type to filter">
   <ul id="pickerList"></ul>
   <button id="pickerCancel" class="btn">Cancel</button>
 </div>
-
-<footer>© 2025 JitaDesWadyas</footer>
-
+<footer>© 2025 JitaDesWadyas</footer>
 <script>
-const q=s=>document.querySelector(s), qq=s=>document.querySelectorAll(s);
-let gameData={}, currentObj=null, encounter={monsters:[]};
-
+const q=s=>document.querySelector(s),qq=s=>document.querySelectorAll(s);
+let gameData={},currentObj=null,encounter={monsters:[]};
+function costStr(o){
+  return (o.time||2)+'s / '+o.cost.amount+' '+(o.cost.resource=='stamina'?'STA':'MP');
+}
+function descStr(o){
+  return o.effect?.dice ? o.effect.dice+' '+(o.effect.kind||'') : o.effect?.kind||'';
+}
+function createItem(o){
+  const div=document.createElement('div');
+  div.className='action-item';
+  div.innerHTML=`<div class="title"><span>${o.name}</span><small>${costStr(o)}</small></div><div class="details">${descStr(o)}</div>`;
+  div.querySelector('.title').onclick=()=>{
+    const d=div.querySelector('.details');
+    d.style.display=d.style.display==='block'?'none':'block';
+  };
+  return div;
+}
+function renderMonsterActions(m,index){
+  const allSkills=gameData.skills,allSpells=gameData.spells;
+  const baseIds=['move','basic-strike','jump'];
+  const basicIds=['dodge','parry','grapple','shove'];
+  const adv=m.skills.filter(id=>!baseIds.includes(id)&&!basicIds.includes(id));
+  const spells=m.skills.filter(id=>allSpells.find(s=>s.id===id));
+  baseIds.forEach(id=>{
+    const o=allSkills.find(s=>s.id===id);
+    if(o)document.getElementById(`monster-baseActions-${index}`).appendChild(createItem(o));
+  });
+  basicIds.forEach(id=>{
+    const o=allSkills.find(s=>s.id===id);
+    if(o)document.getElementById(`monster-basicSkills-${index}`).appendChild(createItem(o));
+  });
+  let aIdx=0;
+  function renderAdv(){
+    const c=document.getElementById(`monster-advSkills-${index}`);
+    c.innerHTML='';
+    adv.slice(aIdx,aIdx+6).forEach(id=>{
+      const o=allSkills.find(s=>s.id===id);
+      if(o)c.appendChild(createItem(o));
+    });
+  }
+  const advBtns=document.querySelectorAll(`#monster-advSkills-${index} ~ summary .btn-nav`);
+  advBtns[0].onclick=()=>{aIdx=Math.max(0,aIdx-6);renderAdv();};
+  advBtns[1].onclick=()=>{aIdx=Math.min(adv.length-6,aIdx+6);renderAdv();};
+  renderAdv();
+  let spIdx=0;
+  function renderSp(){
+    const c=document.getElementById(`monster-spellList-${index}`);
+    c.innerHTML='';
+    spells.slice(spIdx,spIdx+6).forEach(id=>{
+      const o=allSpells.find(s=>s.id===id);
+      if(o)c.appendChild(createItem(o));
+    });
+  }
+  const spBtns=document.querySelectorAll(`#monster-spellList-${index} ~ summary .btn-nav`);
+  spBtns[0].onclick=()=>{spIdx=Math.max(0,spIdx-6);renderSp();};
+  spBtns[1].onclick=()=>{spIdx=Math.min(spells.length-6,spIdx+6);renderSp();};
+  renderSp();
+}
 async function init(){
-  // load gamedata
   const ls=localStorage.getItem('gamedata');
   if(ls) gameData=JSON.parse(ls);
-  else {
+  else{
     gameData=await fetch('gamedata.json').then(r=>r.json());
     localStorage.setItem('gamedata',JSON.stringify(gameData));
   }
-  renderGameDataList();
+  renderGdList();
   fillMonsterSelect();
   loadEncounter();
   renderEncounter();
   hookUI();
 }
-
 function hookUI(){
-  // export/import gamedata
   q('#exportGameDataBtn').onclick=_=>{
     const a=document.createElement('a');
     a.href=URL.createObjectURL(new Blob([JSON.stringify(gameData,null,2)],{type:'application/json'}));
-    a.download='gamedata.json'; a.click();
+    a.download='gamedata.json';
+    a.click();
   };
   q('#importGameDataBtn').onclick=_=>q('#importGameDataFile').click();
   q('#importGameDataFile').onchange=e=>{
@@ -184,23 +267,20 @@ function hookUI(){
       try{
         gameData=JSON.parse(ev.target.result);
         localStorage.setItem('gamedata',JSON.stringify(gameData));
-        renderGameDataList(); fillMonsterSelect();
+        renderGdList();
+        fillMonsterSelect();
       }catch{
         alert('JSON non valido');
       }
     };
     r.readAsText(e.target.files[0]);
   };
-
-  // switch type fields
   q('#typeSel').onchange=()=>{
     qq('.type-fields').forEach(d=>d.style.display='none');
     q('#'+q('#typeSel').value+'Fields').style.display='block';
     q('#delBtn').style.display='none';
     q('#gd_id').value='';
   };
-
-  // save/update
   q('#saveBtn').onclick=_=>{
     const type=q('#typeSel').value;
     const obj=currentObj||{};
@@ -208,33 +288,27 @@ function hookUI(){
     obj.id=q('#gd_id').value.trim()||q('#gd_name').value.trim().toLowerCase().replace(/\s+/g,'-');
     obj.name=q('#gd_name').value.trim();
     obj.description=q('#gd_description').value.trim();
-
     if(type==='skill'){
       obj.type=q('#gd_type').value;
       obj.time=+q('#gd_time').value;
       obj.cost={resource:q('#gd_cost_resource').value,amount:+q('#gd_cost_amount').value};
       try{obj.effect=JSON.parse(q('#gd_effect_json').value);}catch{alert('Effect JSON non valido');return;}
-    }
-    else if(type==='spell'){
+    }else if(type==='spell'){
       obj.time=+q('#gd_time').value;
       try{obj.cost=JSON.parse(q('#gd_spell_cost_json').value);}catch{alert('Cost JSON non valido');return;}
       try{obj.effect=JSON.parse(q('#gd_spell_effect_json').value);}catch{alert('Effect JSON non valido');return;}
-    }
-    else if(type==='weapon'){
+    }else if(type==='weapon'){
       obj.type=q('#gd_weapon_type').value;
       try{obj.damage=JSON.parse(q('#gd_weapon_damage_json').value);}catch{alert('Damage JSON non valido');return;}
       obj.notes=q('#gd_weapon_notes').value.trim();
-    }
-    else if(type==='armor'){
+    }else if(type==='armor'){
       obj.slot=q('#gd_armor_slot').value;
       obj.def=+q('#gd_armor_def').value;
       obj.penalty=q('#gd_armor_penalty').value.trim();
-    }
-    else if(type==='item'){
+    }else if(type==='item'){
       obj.type=q('#gd_item_type').value;
       try{obj.effect=JSON.parse(q('#gd_item_effect_json').value);}catch{alert('Effect JSON non valido');return;}
-    }
-    else if(type==='monster'){
+    }else if(type==='monster'){
       obj.hp=+q('#gd_hp').value;
       obj.stamina=+q('#gd_stamina').value;
       obj.mana=+q('#gd_mana').value;
@@ -248,89 +322,56 @@ function hookUI(){
       obj.loot=q('#gd_loot').value.trim();
       obj.skills=(currentObj&&currentObj.skills)||[];
     }
-
-    // upsert
-    const key= obj.category+'s';
+    const key=obj.category+'s';
     gameData[key]=gameData[key]||[];
     const idx=gameData[key].findIndex(o=>o.id===obj.id);
-    if(idx>-1) gameData[key][idx]=obj;
-    else gameData[key].push(obj);
+    if(idx>-1) gameData[key][idx]=obj; else gameData[key].push(obj);
     localStorage.setItem('gamedata',JSON.stringify(gameData));
-
-    renderGameDataList();
+    renderGdList();
     fillMonsterSelect();
     clearFields();
   };
-
-  // delete
   q('#delBtn').onclick=_=>{
     if(!currentObj) return;
-    const cat=currentObj.category, id=currentObj.id;
+    const cat=currentObj.category,id=currentObj.id;
     gameData[cat+'s']=gameData[cat+'s'].filter(o=>o.id!==id);
     localStorage.setItem('gamedata',JSON.stringify(gameData));
-    renderGameDataList();
+    renderGdList();
     fillMonsterSelect();
     clearFields();
   };
-
-  // filter & load
-  q('#filterInput').oninput=renderGameDataList;
-  q('#gamedataList').onclick=e=>{
-    const d=e.target.closest('.del-entry');
-    if(d){
-      const cat=d.dataset.cat, id=d.dataset.id;
-      gameData[cat+'s']=gameData[cat+'s'].filter(o=>o.id!==id);
-      localStorage.setItem('gamedata',JSON.stringify(gameData));
-      renderGameDataList();
-      fillMonsterSelect();
-      if(currentObj&&currentObj.id===id) clearFields();
-      return;
-    }
-    const li=e.target.closest('li[data-id]');
-    if(!li) return;
-    loadEntry(li.dataset.cat,li.dataset.id);
+  q('#gdFilter').oninput=renderGdList;
+  q('#gdataList').onclick=e=>{
+    const item=e.target.closest('.editor-item');
+    if(!item) return;
+    editGd(item.dataset.id,item.dataset.cat);
   };
-
-  // monster-skill picker in editor
   q('#addGDMonsterSkill').onclick=_=>{
     openPicker(gameData.skills,addGDMonsterSkill);
   };
-
-  // encounter manager
   q('#addMonster').onclick=_=>{
     spawnMonster(q('#monsterSelect').value);
   };
+  document.getElementById('globalFilter').oninput=()=>{
+    const f=document.getElementById('globalFilter').value.toLowerCase();
+    fillMonsterSelect(f);
+    renderGdList(f);
+  };
+}
+function renderGdList(f=''){
+  const type=document.getElementById('typeSel').value;
+  const arr=gameData[type+'s']||[];
+  if(!f) f=document.getElementById('gdFilter').value.toLowerCase();
+  document.getElementById('gdataList').innerHTML=arr.filter(o=>o.name.toLowerCase().includes(f)).map(o=>`<div class="editor-item" data-id="${o.id}" data-cat="${type}"><div class="title">${o.name}</div></div>`).join('');
+}
+function fillMonsterSelect(f=""){
+  const sel=document.getElementById("monsterSelect");
+  const list=(gameData.monsters||[]).filter(m=>m.name.toLowerCase().includes(f));
+  sel.innerHTML=list.map(m=>`<option value="${m.id}">${m.name}</option>`).join("");
 }
 
-// render list
-function renderGameDataList(){
-  const f=q('#filterInput').value.toLowerCase();
-  const all=[
-    ...(gameData.skills||[]),
-    ...(gameData.spells||[]),
-    ...(gameData.weapons||[]),
-    ...(gameData.armors||[]),
-    ...(gameData.items||[]),
-    ...(gameData.monsters||[])
-  ];
-  q('#gamedataList').innerHTML=all
-    .filter(o=>o.name.toLowerCase().includes(f))
-    .map(o=>`
-      <li data-id="${o.id}" data-cat="${o.category}">
-        ${o.name}
-        <button class="del-entry" data-id="${o.id}" data-cat="${o.category}">×</button>
-      </li>
-    `).join('');
-}
+function editGd(id,cat){
 
-// fill monster dropdown
-function fillMonsterSelect(){
-  q('#monsterSelect').innerHTML=
-    (gameData.monsters||[]).map(m=>`<option value="${m.id}">${m.name}</option>`).join('');
-}
-
-// load one entry into editor
-function loadEntry(cat,id){
   const src=(gameData[cat+'s']||[]).find(o=>o.id===id);
   if(!src) return;
   currentObj=JSON.parse(JSON.stringify(src));
@@ -339,34 +380,28 @@ function loadEntry(cat,id){
   q('#gd_id').value=currentObj.id;
   q('#gd_name').value=currentObj.name;
   q('#gd_description').value=currentObj.description||'';
-
   if(cat==='skill'){
     q('#gd_type').value=currentObj.type;
     q('#gd_time').value=currentObj.time;
     q('#gd_cost_resource').value=currentObj.cost.resource;
     q('#gd_cost_amount').value=currentObj.cost.amount;
     q('#gd_effect_json').value=JSON.stringify(currentObj.effect);
-  }
-  else if(cat==='spell'){
+  }else if(cat==='spell'){
     q('#gd_time').value=currentObj.time;
     q('#gd_spell_cost_json').value=JSON.stringify(currentObj.cost);
     q('#gd_spell_effect_json').value=JSON.stringify(currentObj.effect);
-  }
-  else if(cat==='weapon'){
+  }else if(cat==='weapon'){
     q('#gd_weapon_type').value=currentObj.type;
     q('#gd_weapon_damage_json').value=JSON.stringify(currentObj.damage);
     q('#gd_weapon_notes').value=currentObj.notes||'';
-  }
-  else if(cat==='armor'){
+  }else if(cat==='armor'){
     q('#gd_armor_slot').value=currentObj.slot;
     q('#gd_armor_def').value=currentObj.def;
     q('#gd_armor_penalty').value=currentObj.penalty||'';
-  }
-  else if(cat==='item'){
+  }else if(cat==='item'){
     q('#gd_item_type').value=currentObj.type;
     q('#gd_item_effect_json').value=JSON.stringify(currentObj.effect);
-  }
-  else if(cat==='monster'){
+  }else if(cat==='monster'){
     q('#gd_hp').value=currentObj.hp;
     q('#gd_stamina').value=currentObj.stamina;
     q('#gd_mana').value=currentObj.mana;
@@ -380,21 +415,17 @@ function loadEntry(cat,id){
     q('#gd_loot').value=currentObj.loot||'';
     renderGDMonsterSkills();
   }
-
   q('#delBtn').style.display='inline-block';
 }
-
 function clearFields(){
   currentObj=null;
   q('#gd_id').value='';
   q('#gd_name').value='';
   q('#gd_description').value='';
-  qq('.type-fields input, .type-fields textarea, .type-fields select').forEach(el=>el.value=el.defaultValue||'');
+  qq('.type-fields input,.type-fields textarea,.type-fields select').forEach(el=>el.value=el.defaultValue||'');
   q('#delBtn').style.display='none';
   clearGDMonsterSkills();
 }
-
-// monster-skill table in editor
 function renderGDMonsterSkills(){
   const tb=q('#gd_skills_table tbody');
   if(!tb) return;
@@ -403,10 +434,7 @@ function renderGDMonsterSkills(){
     const o=gameData.skills.find(s=>s.id===id);
     if(!o) return;
     const tr=document.createElement('tr');
-    tr.innerHTML=`
-      <td>${o.name}</td>
-      <td><button class="delGDSkill btn" data-id="${id}">×</button></td>
-    `;
+    tr.innerHTML=`<td>${o.name}</td><td><button class="delGDSkill btn" data-id="${id}">×</button></td>`;
     tb.appendChild(tr);
   });
   qq('.delGDSkill').forEach(b=>b.onclick=_=>{
@@ -414,22 +442,20 @@ function renderGDMonsterSkills(){
     renderGDMonsterSkills();
   });
 }
-
 function clearGDMonsterSkills(){
   const tb=q('#gd_skills_table tbody');
   if(tb) tb.innerHTML='';
 }
-
 function addGDMonsterSkill(obj){
   if(!currentObj.skills) currentObj.skills=[];
   if(!currentObj.skills.includes(obj.id)) currentObj.skills.push(obj.id);
   renderGDMonsterSkills();
 }
-
-// generic picker
 function openPicker(data,onSelect){
-  const box=q('#picker'), list=q('#pickerList'), inp=q('#pickerSearch');
-  box.style.display='flex'; inp.value=''; render('');
+  const box=q('#picker'),list=q('#pickerList'),inp=q('#pickerSearch');
+  box.style.display='flex';
+  inp.value='';
+  render('');
   inp.oninput=e=>render(e.target.value.toLowerCase());
   list.onclick=e=>{
     const li=e.target.closest('li');
@@ -439,11 +465,8 @@ function openPicker(data,onSelect){
   };
   q('#pickerCancel').onclick=close;
   document.onkeydown=ev=>ev.key==='Escape'&&close();
-
   function render(f){
-    list.innerHTML=data
-      .filter(o=>o.name.toLowerCase().includes(f))
-      .map(o=>`<li data-id="${o.id}">${o.name}</li>`).join('');
+    list.innerHTML=data.filter(o=>o.name.toLowerCase().includes(f)).map(o=>`<li data-id="${o.id}">${o.name}</li>`).join('');
   }
   function close(){
     box.style.display='none';
@@ -453,8 +476,6 @@ function openPicker(data,onSelect){
     document.onkeydown=null;
   }
 }
-
-// encounter persistence
 function loadEncounter(){
   const ls=sessionStorage.getItem('encounter');
   if(ls) encounter=JSON.parse(ls);
@@ -462,8 +483,6 @@ function loadEncounter(){
 function persistEncounter(){
   sessionStorage.setItem('encounter',JSON.stringify(encounter));
 }
-
-// spawn & render encounter
 function spawnMonster(id){
   const src=(gameData.monsters||[]).find(m=>m.id===id);
   if(!src) return;
@@ -479,72 +498,48 @@ function spawnMonster(id){
   renderEncounter();
   persistEncounter();
 }
-
 function renderEncounter(){
-  q('#encounterArea').innerHTML=encounter.monsters.map((m,i)=>`
-    <div class="monster-card">
+  const html=encounter.monsters.map((m,i)=>{
+    return `<div class="monster-card">
       <strong>${m.name}</strong>
       <button class="del btn" data-i="${i}">×</button>
-      ${['hp','stamina','mana','time'].map(k=>`
-        <div class="slider-wrap">
-          ${k.toUpperCase()}
-          <input type="range" class="bar" data-i="${i}" data-k="${k}"
-            min="0" max="${m['max'+capitalize(k)]||m[k]}" value="${m[k]}">
-          <span>${m[k]}</span>
-        </div>`).join('')}
-      <button class="finish btn" data-i="${i}">End Turn</button><br>
-      ${(m.skills||[]).map(s=>`
-        <button class="act btn" data-s="${s}" data-i="${i}">
-          ${skillName(s)}
-        </button>`).join('')}
-    </div>`).join('');
-
-  // handlers
+      <div class="slider-wrap">HP <input type="range" class="bar" data-i="${i}" data-k="hp" min="0" max="${m.maxHp}" value="${m.hp}"><span>${m.hp}</span></div>
+      <div class="slider-wrap">ST <input type="range" class="bar" data-i="${i}" data-k="stamina" min="0" max="${m.maxStamina}" value="${m.stamina}"><span>${m.stamina}</span></div>
+      <div class="slider-wrap">MP <input type="range" class="bar" data-i="${i}" data-k="mana" min="0" max="${m.maxMana}" value="${m.mana}"><span>${m.mana}</span></div>
+      <div class="slider-wrap">TIME <input type="range" class="bar" data-i="${i}" data-k="time" min="0" max="${m.maxTime}" value="${m.time}"><span>${m.time}</span></div>
+      <details open>
+        <summary>Base Actions</summary>
+        <div class="action-list" id="monster-baseActions-${i}"></div>
+      </details>
+      <details open>
+        <summary>Basic Skills</summary>
+        <div class="action-list" id="monster-basicSkills-${i}"></div>
+      </details>
+      <details>
+        <summary>Advanced Skills <button class="btn-nav" data-dir="-6">◀</button><button class="btn-nav" data-dir="+6">▶</button></summary>
+        <div class="action-list" id="monster-advSkills-${i}"></div>
+      </details>
+      <details>
+        <summary>Spells <button class="btn-nav" data-dir="-6">◀</button><button class="btn-nav" data-dir="+6">▶</button></summary>
+        <div class="action-list" id="monster-spellList-${i}"></div>
+      </details>
+    </div>`;
+  }).join('');
+  q('#encounterArea').innerHTML=html;
   qq('.del').forEach(b=>b.onclick=_=>{
     encounter.monsters.splice(+b.dataset.i,1);
-    renderEncounter(); persistEncounter();
+    renderEncounter();
+    persistEncounter();
   });
   qq('.bar').forEach(sl=>sl.oninput=_=>{
-    const i=+sl.dataset.i, k=sl.dataset.k;
+    const i=+sl.dataset.i,k=sl.dataset.k;
     encounter.monsters[i][k]=+sl.value;
     sl.nextElementSibling.textContent=sl.value;
     persistEncounter();
   });
-  qq('.finish').forEach(b=>b.onclick=_=>{
-    const m=encounter.monsters[+b.dataset.i];
-    m.time=m.maxTime;
-    if(m.maxStamina>0) m.stamina=Math.min(m.maxStamina,m.stamina+1);
-    if(m.maxMana>0) m.mana=Math.min(m.maxMana,m.mana+1);
-    renderEncounter(); persistEncounter();
-  });
-  qq('.act').forEach(b=>b.onclick=_=>{
-    const i=+b.dataset.i, sid=b.dataset.s;
-    const m=encounter.monsters[i];
-    const obj=(gameData.skills||[]).find(o=>o.id===sid)
-           ||(gameData.spells||[]).find(o=>o.id===sid);
-    if(!obj) return;
-    const costRes=(obj.cost&&obj.cost.resource)==='mana'?'mana':'stamina';
-    const timeCost=obj.time||2;
-    if(m[costRes]<obj.cost.amount||m.time<timeCost){
-      alert('Resources insufficient'); return;
-    }
-    m[costRes]-=obj.cost.amount;
-    m.time-=timeCost;
-    renderEncounter(); persistEncounter();
-  });
+  encounter.monsters.forEach((m,idx)=>renderMonsterActions(m,idx));
 }
-
-function capitalize(s){
-  return s.charAt(0).toUpperCase()+s.slice(1);
-}
-
-function skillName(id){
-  const s=(gameData.skills||[]).find(o=>o.id===id)
-         ||(gameData.spells||[]).find(o=>o.id===id);
-  return s?s.name:id;
-}
-
-init();
+window.addEventListener('load',init);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redesign dungeon_master.html to integrate action-list layout from the character sheet
- add global filter and per-category filtering in the Game Data editor
- add monster action rendering for encounter manager

## Testing
- `node - <<'EOF'
const fs = require('fs');
const html = fs.readFileSync('dungeon_master.html','utf8');
const script = html.match(/<script>([\s\S]*?)<\/script>/)[1];
new Function(script);
console.log('OK');
EOF`

------
https://chatgpt.com/codex/tasks/task_e_687904edf0bc8323afcfd89903e0aec5